### PR TITLE
Attempt to fix auth looping problem with MSAL login

### DIFF
--- a/src/create-core-app/aad/A01-begin-app/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A01-begin-app/client/identity/identityClient.js
@@ -99,14 +99,10 @@ async function getAccessToken2() {
             console.warn("Silent token acquisition failed; acquiring token using redirect");
             msalClient.acquireTokenRedirect(msalRequest);
         } else {
-            throw (error);
+            throw (error.message);
         }
     }
 }
-
-// export async function setLoggedinEmployeeId(employeeId) {
-//     document.cookie = `employeeId=${employeeId};SameSite=None;Secure;path=/`;
-// }
 
 // Get the employee profile from our web service
 export async function getLoggedInEmployee() {

--- a/src/create-core-app/aad/A01-begin-app/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A01-begin-app/client/identity/identityClient.js
@@ -97,7 +97,7 @@ async function getAccessToken2() {
     } catch (error) {
         if (error instanceof msal.InteractionRequiredAuthError) {
             console.warn("Silent token acquisition failed; acquiring token using redirect");
-            this.msalClient.acquireTokenRedirect(this.request);
+            msalClient.acquireTokenRedirect(msalRequest);
         } else {
             throw (error);
         }

--- a/src/create-core-app/aad/A02-after-teams-sso/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A02-after-teams-sso/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/create-core-app/aad/A02-after-teams-sso/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A02-after-teams-sso/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/create-core-app/aad/A03-after-apply-styling/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A03-after-apply-styling/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/create-core-app/aad/A03-after-apply-styling/client/identity/identityClient.js
+++ b/src/create-core-app/aad/A03-after-apply-styling/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/extend-with-capabilities/All/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/All/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/extend-with-capabilities/All/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/All/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/extend-with-capabilities/ConfigurableTab/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/ConfigurableTab/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/extend-with-capabilities/ConfigurableTab/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/ConfigurableTab/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/extend-with-capabilities/Deeplink/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Deeplink/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/extend-with-capabilities/Deeplink/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Deeplink/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/extend-with-capabilities/Dialog/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Dialog/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/extend-with-capabilities/Dialog/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Dialog/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/extend-with-capabilities/MeetingConfigurableTab/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/MeetingConfigurableTab/client/identity/identityClient.js
@@ -5,6 +5,16 @@ import { env } from '/modules/env.js';
 import { ensureTeamsSdkInitialized, inTeams } from '/modules/teamsHelpers.js';
 import 'https://res.cdn.office.net/teams-js/2.0.0/js/MicrosoftTeams.min.js';
 
+// interface IIdentityClient {
+//     async getLoggedinEmployeeId(): number;
+//     async setLoggedinEmployeeId(employeeId: number): void;
+//     async validateEmployeeLogin(surname: string, password: string): Number;
+//     async getLoggedInEmployee(): IEmployee;
+//     async Logoff(): void                    // Redirects and does not return
+//     async getFetchHeadersAnon(): string;    // headers for calling Fetch anonymously
+//     async getFetchHeadersAuth(): string;    // headers for calling Fetch with authentication
+// }
+
 const msalConfig = {
     auth: {
         clientId: env.CLIENT_ID,
@@ -22,7 +32,7 @@ const msalRequest = {
     scopes: [`api://${env.HOST_NAME}/${env.CLIENT_ID}/access_as_user`]
 }
 
-const msalClient = new msal.PublicClientApplication(msalConfig);
+const msalClient = new msal.PublicClientApplication (msalConfig);
 
 let getLoggedInEmployeeIdPromise;        // Cache the promise so we only do the work once on this page
 export function getLoggedinEmployeeId() {
@@ -66,9 +76,9 @@ export function getAccessToken() {
 
 async function getAccessToken2() {
 
-    if (await inTeams()) {
+    if (await inTeams()) {        
         await ensureTeamsSdkInitialized();
-        return await microsoftTeams.authentication.getAuthToken();
+        return await microsoftTeams.authentication.getAuthToken();  
     } else {
 
         // If we were waiting for a redirect with an auth code, handle it here
@@ -95,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/extend-with-capabilities/MeetingConfigurableTab/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/MeetingConfigurableTab/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/extend-with-capabilities/MessagingExtension/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/MessagingExtension/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/extend-with-capabilities/MessagingExtension/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/MessagingExtension/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }

--- a/src/extend-with-capabilities/Monetization/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Monetization/client/identity/identityClient.js
@@ -105,7 +105,7 @@ async function getAccessToken2() {
         } catch (error) {
             if (error instanceof msal.InteractionRequiredAuthError) {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
-                this.msalClient.acquireTokenRedirect(this.request);
+                msalClient.acquireTokenRedirect(msalRequest);
             } else {
                 throw (error);
             }

--- a/src/extend-with-capabilities/Monetization/client/identity/identityClient.js
+++ b/src/extend-with-capabilities/Monetization/client/identity/identityClient.js
@@ -107,7 +107,7 @@ async function getAccessToken2() {
                 console.warn("Silent token acquisition failed; acquiring token using redirect");
                 msalClient.acquireTokenRedirect(msalRequest);
             } else {
-                throw (error);
+                throw (error.message);
             }
         }
     }


### PR DESCRIPTION
I found one glaring error and fixed it, but still can't log in reliably when a 2nd AAD account is also logged into Windows and I am using a browser that is aware of Windows login integration. May also still happen when any 2nd AAD account is present.

Work-around is to use privacy mode but still hoping for a fix here. Slightly improved error reporting.