### PR TITLE
Fix minor typos

### DIFF
--- a/docs/aad/MeetingConfigurableTab.md
+++ b/docs/aad/MeetingConfigurableTab.md
@@ -57,7 +57,7 @@ Now, immediately under the `scopes` array, in the your configurable tab object, 
       "configurationUrl": "https://<HOST_NAME>/pages/tabConfig.html",
       "canUpdateConfiguration": true,
       "scopes": [
-        "teams",
+        "team",
         "groupchat"
       ],
       "context": [

--- a/docs/aad/MeetingConfigurableTab.md
+++ b/docs/aad/MeetingConfigurableTab.md
@@ -33,7 +33,7 @@ In this lab you will learn to:
 
 - Microsoft Teams configurable tab to display a product category in during pre-meeting stage
 - Microsoft Teams configurable tab to display a product category in the Meeting Side Panel during a Teams meeting
-- Microosft Teams configurable tab to display a product category and be shared to the Meeting Content Stage
+- Microsoft Teams configurable tab to display a product category and be shared to the Meeting Content Stage
 
 ### Exercise 1: Update your configurable tab for use with Meetings
 


### PR DESCRIPTION
Fix typo in the page :
- Microsoft (from Micrsooft)
- 'team' (from 'teams') ([source](https://learn.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/build-tabs-for-meeting?tabs=desktop#configure-tab-app-for-a-meeting))