### PR TITLE
Fixed the typo of `HOSTNAME` .env key in docs. Closes #117

### DIFF
--- a/docs/aad/A01-begin-app.md
+++ b/docs/aad/A01-begin-app.md
@@ -407,7 +407,7 @@ In a code editor, open the working folder you created in Step 2. Copy the *.env_
 COMPANY_NAME=Northwind Traders
 PORT=3978
 
-HOSTNAME=something.ngrok.io
+HOST_NAME=something.ngrok.io
 TENANT_ID=00000000-0000-0000-0000-000000000000
 CLIENT_ID=00000000-0000-0000-0000-000000000000
 CLIENT_SECRET=xxxxx


### PR DESCRIPTION
There was a typo for the key called `HOSTNAME` in the environment value information. This PR fixes that typo and changes the key to **`HOST_NAME`** which matches with the actual .env information.

Closes #117 